### PR TITLE
Fix TLS parameter for aiohttp connector

### DIFF
--- a/aiobedrock/main.py
+++ b/aiobedrock/main.py
@@ -23,7 +23,6 @@ class Client:
             ttl_dns_cache=3600,
             use_dns_cache=True,
             enable_cleanup_closed=True,
-            verify_ssl=True,
         )
         self.session = aiohttp.ClientSession(connector=conn)
         boto3_session = boto3.Session(region_name=region_name)


### PR DESCRIPTION
## Summary
- fix aiohttp TCPConnector creation by removing invalid `verify_ssl` argument

## Testing
- `python -m py_compile aiobedrock/main.py`
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=42)*

------
https://chatgpt.com/codex/tasks/task_b_683d8a47b4a08323a3a5af4b4efec65d