### PR TITLE
Add async SageMaker endpoint invocation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ dist-ssr
 *.pyc
 .venv
 myenv
+.uv_cache
+.pytest_cache

--- a/aiobedrock.egg-info/PKG-INFO
+++ b/aiobedrock.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: aiobedrock
-Version: 0.3.0
+Version: 0.3.1
 Summary: AWS boto3 bedrock client in async
 Home-page: https://github.com/Phicks-debug/aiobedrock
 Author: Phicks

--- a/aiobedrock/main.py
+++ b/aiobedrock/main.py
@@ -14,6 +14,7 @@ from typing import (
     Union,
     overload,
 )
+from urllib.parse import urlparse
 
 import aiohttp
 import boto3
@@ -280,6 +281,90 @@ class Client:
 
             try:
                 async with self._request(url=url, headers=headers, data=body) as res:  # noqa: E501
+                    await self._handle_error_response(res)
+                    return await res.read()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                if not self._should_retry(exc, attempt):
+                    raise
+                await self._sleep_backoff(attempt)
+                attempt += 1
+
+    async def invoke_sagemaker_endpoint(
+        self,
+        endpoint_name: str,
+        *,
+        body: Union[str, bytes],
+        content_type: Optional[str] = None,
+        accept: Optional[str] = None,
+        custom_attributes: Optional[str] = None,
+        target_variant: Optional[str] = None,
+        target_model: Optional[str] = None,
+        target_container_hostname: Optional[str] = None,
+        target_channel: Optional[str] = None,
+        inference_component: Optional[str] = None,
+        inference_id: Optional[str] = None,
+        endpoint_config_name: Optional[str] = None,
+        invocation_timeout_seconds: Optional[int] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> bytes:
+        """Invoke a SageMaker endpoint asynchronously."""
+
+        url = (
+            f"https://runtime.sagemaker.{self.region_name}.amazonaws.com"
+            f"/endpoints/{endpoint_name}/invocations"
+        )
+
+        attempt = 0
+        while True:
+            await self._ensure_valid_credentials()
+
+            extra_headers: Dict[str, str] = {}
+
+            header_mappings = {
+                "X-Amzn-SageMaker-Custom-Attributes": custom_attributes,
+                "X-Amzn-SageMaker-Target-Variant": target_variant,
+                "X-Amzn-SageMaker-Target-Model": target_model,
+                "X-Amzn-SageMaker-Target-Container-Hostname": target_container_hostname,
+                "X-Amzn-SageMaker-Target-Channel": target_channel,
+                "X-Amzn-SageMaker-Inference-Components": inference_component,
+                "X-Amzn-SageMaker-Inference-Id": inference_id,
+                "X-Amzn-SageMaker-Endpoint-Config-Name": endpoint_config_name,
+                "X-Amzn-SageMaker-Invocation-Timeout-Seconds": (
+                    str(invocation_timeout_seconds)
+                    if invocation_timeout_seconds is not None
+                    else None
+                ),
+            }
+
+            for key, value in header_mappings.items():
+                if value is not None:
+                    extra_headers[key] = value
+
+            if headers:
+                for key, value in headers.items():
+                    if value is not None:
+                        extra_headers[key] = value
+
+            signed_headers = self._signed_request(
+                body=body,
+                url=url,
+                method="POST",
+                credentials=self.credentials,
+                region_name=self.region_name,
+                service="sagemaker",
+                accept=accept,
+                contentType=content_type,
+                extra_headers=extra_headers if extra_headers else None,
+            )
+
+            try:
+                async with self._request(
+                    url=url,
+                    headers=signed_headers,
+                    data=body,
+                ) as res:
                     await self._handle_error_response(res)
                     return await res.read()
             except asyncio.CancelledError:
@@ -586,8 +671,11 @@ class Client:
         credentials,
         url: str,
         method: str,
-        body: str,
+        body: Union[str, bytes],
         region_name: str,
+        *,
+        service: str = "bedrock",
+        extra_headers: Optional[Mapping[str, str]] = None,
         **kwargs,
     ) -> Dict[str, str]:
         """Create a signed AWS request"""
@@ -598,49 +686,61 @@ class Client:
             credentials = credentials.get_frozen_credentials()
 
         request = AWSRequest(method=method, url=url, data=body)
-        request.headers.add_header("Host", url.split("/")[2])
+        request.headers.add_header("Host", urlparse(url).netloc)
 
-        # Set appropriate headers based on the endpoint
-        if "invoke-with-response-stream" in url:
-            request.headers.add_header(
-                "Accept",
-                "application/vnd.amazon.eventstream",
-            )
-        else:
-            request.headers.add_header(
-                "Accept", kwargs.get("accept", "application/json")
-            )
+        accept_header = kwargs.get("accept")
+        content_type = kwargs.get("contentType")
 
-        request.headers.add_header(
-            "Content-Type", kwargs.get("contentType", "application/json")
-        )
-        request.headers.add_header(
-            "X-Amzn-Bedrock-Trace", kwargs.get("trace", "DISABLED")
-        )
-
-        # Optional headers
-        optional_headers = [
-            (
-                "guardrailIdentifier",
-                "X-Amzn-Bedrock-GuardrailIdentifier",
-            ),
-            (
-                "guardrailVersion",
-                "X-Amzn-Bedrock-GuardrailVersion",
-            ),
-            (
-                "performanceConfigLatency",
-                "X-Amzn-Bedrock-PerformanceConfig-Latency",
-            ),
-        ]
-
-        for kwarg_key, header_name in optional_headers:
-            if kwargs.get(kwarg_key):
+        if service == "bedrock":
+            # Set appropriate headers based on the endpoint
+            if "invoke-with-response-stream" in url:
                 request.headers.add_header(
-                    header_name,
-                    kwargs.get(kwarg_key),  # type: ignore
+                    "Accept",
+                    "application/vnd.amazon.eventstream",
+                )
+            else:
+                request.headers.add_header(
+                    "Accept", accept_header or "application/json"
                 )
 
+            request.headers.add_header(
+                "Content-Type", content_type or "application/json"
+            )
+            request.headers.add_header(
+                "X-Amzn-Bedrock-Trace", kwargs.get("trace", "DISABLED")
+            )
+
+            # Optional headers specific to Bedrock
+            optional_headers = [
+                (
+                    "guardrailIdentifier",
+                    "X-Amzn-Bedrock-GuardrailIdentifier",
+                ),
+                (
+                    "guardrailVersion",
+                    "X-Amzn-Bedrock-GuardrailVersion",
+                ),
+                (
+                    "performanceConfigLatency",
+                    "X-Amzn-Bedrock-PerformanceConfig-Latency",
+                ),
+            ]
+
+            for kwarg_key, header_name in optional_headers:
+                value = kwargs.get(kwarg_key)
+                if value:
+                    request.headers.add_header(header_name, value)  # type: ignore[arg-type]
+        else:
+            if accept_header is not None:
+                request.headers.add_header("Accept", accept_header)
+            if content_type is not None:
+                request.headers.add_header("Content-Type", content_type)
+
+        if extra_headers:
+            for key, value in extra_headers.items():
+                if value is not None:
+                    request.headers.add_header(key, value)
+
         # Sign the request
-        SigV4Auth(credentials, "bedrock", region_name).add_auth(request)
+        SigV4Auth(credentials, service, region_name).add_auth(request)
         return dict(request.headers)

--- a/aiobedrock/main.py
+++ b/aiobedrock/main.py
@@ -326,7 +326,7 @@ class Client:
                 "X-Amzn-SageMaker-Custom-Attributes": custom_attributes,
                 "X-Amzn-SageMaker-Target-Variant": target_variant,
                 "X-Amzn-SageMaker-Target-Model": target_model,
-                "X-Amzn-SageMaker-Target-Container-Hostname": target_container_hostname,
+                "X-Amzn-SageMaker-Target-Container-Hostname": target_container_hostname,  # noqa: E501
                 "X-Amzn-SageMaker-Target-Channel": target_channel,
                 "X-Amzn-SageMaker-Inference-Components": inference_component,
                 "X-Amzn-SageMaker-Inference-Id": inference_id,
@@ -729,7 +729,10 @@ class Client:
             for kwarg_key, header_name in optional_headers:
                 value = kwargs.get(kwarg_key)
                 if value:
-                    request.headers.add_header(header_name, value)  # type: ignore[arg-type]
+                    request.headers.add_header(
+                        header_name,
+                        value,
+                    )
         else:
             if accept_header is not None:
                 request.headers.add_header("Accept", accept_header)

--- a/example/invoke_model_with_response_stream.py
+++ b/example/invoke_model_with_response_stream.py
@@ -7,7 +7,7 @@ from aiobedrock import Client
 async def main():
     async with Client(
         region_name="ap-southeast-1",
-        assume_role_arn="arn:aws:iam::130506138320:role/bedrock-cross-account-role",  # noqa: E501
+        # assume_role_arn="arn:aws:iam::130506138320:role/bedrock-cross-account-role",  # noqa: E501
     ) as client:
         body = {
             "anthropic_version": "bedrock-2023-05-31",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,9 @@
+import asyncio
 import base64
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from aiobedrock.main import Client
 
@@ -61,3 +66,69 @@ def test_normalize_headers_extracts_values():
         "plain": "value",
         "wrapped": "wrapped-value",
     }
+
+
+def test_invoke_sagemaker_endpoint_builds_headers():
+    client = _make_client()
+    client.region_name = "us-west-2"
+    client.credentials = object()
+
+    async def _no_credentials_refresh():
+        return None
+
+    client._ensure_valid_credentials = _no_credentials_refresh  # type: ignore[assignment]
+
+    captured = {}
+
+    def fake_signed_request(**kwargs):
+        captured["kwargs"] = kwargs
+        return {"Authorization": "test"}
+
+    async def fake_handle_error_response(response):
+        return None
+
+    class DummyResponse:
+        status = 200
+
+        async def read(self):
+            return b"ok"
+
+    class DummyContext:
+        def __init__(self, response):
+            self._response = response
+
+        async def __aenter__(self):
+            return self._response
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_request(**kwargs):
+        captured["request"] = kwargs
+        return DummyContext(DummyResponse())
+
+    client._signed_request = fake_signed_request  # type: ignore[assignment]
+    client._request = fake_request  # type: ignore[assignment]
+    client._handle_error_response = fake_handle_error_response  # type: ignore[assignment]
+
+    result = asyncio.run(
+        client.invoke_sagemaker_endpoint(
+            "demo-endpoint",
+            body=b"data",
+            content_type="application/json",
+            accept="application/json",
+            custom_attributes="attr",
+            target_variant="variant",
+            headers={"X-Custom": "value"},
+        )
+    )
+
+    assert result == b"ok"
+    signed_kwargs = captured["kwargs"]
+    assert signed_kwargs["service"] == "sagemaker"
+    assert signed_kwargs["accept"] == "application/json"
+    assert signed_kwargs["contentType"] == "application/json"
+    assert signed_kwargs["extra_headers"]["X-Amzn-SageMaker-Custom-Attributes"] == "attr"
+    assert signed_kwargs["extra_headers"]["X-Amzn-SageMaker-Target-Variant"] == "variant"
+    assert signed_kwargs["extra_headers"]["X-Custom"] == "value"
+    assert captured["request"]["url"].endswith("/endpoints/demo-endpoint/invocations")


### PR DESCRIPTION
## Summary
- add an async `Client.invoke_sagemaker_endpoint` helper with retry-aware SageMaker header handling
- generalize request signing so the client can target services beyond Bedrock
- cover the new behavior with a unit test that exercises the SageMaker invocation path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f92bb615548327b6b8b31acba5839c